### PR TITLE
Fixing issue with makeState() instantiating multiple Node|Transport clie...

### DIFF
--- a/src/main/java/com/hmsonline/storm/es/trident/NodeClientFactory.java
+++ b/src/main/java/com/hmsonline/storm/es/trident/NodeClientFactory.java
@@ -1,22 +1,33 @@
 package com.hmsonline.storm.es.trident;
 
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.elasticsearch.client.Client;
 import org.elasticsearch.node.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-
-import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
-
-
 public class NodeClientFactory implements ClientFactory {
+    private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(NodeClientFactory.class);
+    private static Map<String, Node> NODES = new HashMap<String, Node>();
+    private static Object MUTEX = new Object();
+
     @Override
+    @SuppressWarnings("rawtypes")
     public Client makeClient(Map conf) {
-        String clusterName = (String)conf.get(CLUSTER_NAME);
-        LOG.info("Attaching node client to cluster: '{}'", clusterName);
-        Node node = nodeBuilder().clusterName(clusterName).client(true).data(false).node();
-        return node.client();
+        String clusterName = (String) conf.get(CLUSTER_NAME);
+        synchronized (MUTEX) {
+            LOG.info("Attaching node client to cluster: '{}'", clusterName);
+            Node node = NODES.get(clusterName);
+            if (node == null) {
+                node = nodeBuilder().clusterName(clusterName).client(true).data(false).node();
+                NODES.put(clusterName, node);
+            }
+            return node.client();
+        }
     }
 }

--- a/src/main/java/com/hmsonline/storm/es/trident/TransportClientFactory.java
+++ b/src/main/java/com/hmsonline/storm/es/trident/TransportClientFactory.java
@@ -1,51 +1,57 @@
 package com.hmsonline.storm.es.trident;
 
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-
 public class TransportClientFactory implements ClientFactory {
+    private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(TransportClientFactory.class);
     public static final int DEFAULT_PORT = 9300;
-
+    private static Map<String, TransportClient> CLIENTS = new HashMap<String, TransportClient>();
+    private static Object MUTEX = new Object();
 
     @Override
+    @SuppressWarnings("rawtypes")
     public Client makeClient(Map conf) {
         ImmutableSettings.Builder settingsBuilder = ImmutableSettings.settingsBuilder();
+        settingsBuilder.put("cluster.name", (String) conf.get(CLUSTER_NAME));
+        
+        synchronized (MUTEX) {
+            String clusterHosts = (String) conf.get(CLUSTER_HOSTS);
+            TransportClient client = CLIENTS.get(clusterHosts);
+            if (client == null) {
+                client = new TransportClient(settingsBuilder);
 
-        settingsBuilder.put("cluster.name", (String)conf.get(CLUSTER_NAME));
+                LOG.info("Creating TransportClient with addresses: '{}'", clusterHosts);
 
-        TransportClient client = new TransportClient(settingsBuilder);
+                // expecting "host:port,host2:port2,host3"
+                if (!StringUtils.isEmpty(clusterHosts)) {
+                    String[] hostPorts = StringUtils.split(clusterHosts, ",");
+                    for (String hostPortStr : hostPorts) {
+                        String[] hostPort = StringUtils.split(hostPortStr, ":");
+                        if (hostPort.length == 2) {
+                            client.addTransportAddress(new InetSocketTransportAddress(hostPort[0], Integer
+                                    .parseInt(hostPort[1])));
+                        } else if (hostPort.length == 1) {
+                            client.addTransportAddress(new InetSocketTransportAddress(hostPort[0], DEFAULT_PORT));
+                        }
+                    }
 
-        String clusterHosts = (String)conf.get(CLUSTER_HOSTS);
-
-        LOG.info("Creating TransportClient with addresses: '{}'", clusterHosts);
-
-        // expecting "host:port,host2:port2,host3"
-        if(!StringUtils.isEmpty(clusterHosts)){
-            String[] hostPorts = StringUtils.split(clusterHosts, ",");
-            for (String hostPortStr : hostPorts){
-                String[] hostPort = StringUtils.split(hostPortStr, ":");
-                if(hostPort.length == 2){
-                    client.addTransportAddress(new InetSocketTransportAddress(hostPort[0], Integer.parseInt(hostPort[1])));
-                } else if (hostPort.length == 1){
-                    client.addTransportAddress(new InetSocketTransportAddress(hostPort[0], DEFAULT_PORT));
+                } else {
+                    throw new IllegalStateException("Settings for '" + CLUSTER_HOSTS
+                            + "' can not be empty when using the Transport Client");
                 }
-
+                CLIENTS.put(clusterHosts, client);
             }
-
-        } else {
-            throw new IllegalStateException("Settings for '" + CLUSTER_HOSTS + "' can not be empty when using the Transport Client");
-        }
-
-        return client;
+            return client;
+        }        
     }
 }


### PR DESCRIPTION
...nts.

(one for each call)

Now, clients are re-used across makeState() calls.  A map is used to allow for multiple
connections across clusters.  The key for the map is the clusterName|clusterHosts.  The value is
the node|client.
